### PR TITLE
Revert "chore: repo cached method refactor"

### DIFF
--- a/lib/package_provider/cached_repository.rb
+++ b/lib/package_provider/cached_repository.rb
@@ -24,21 +24,9 @@ module PackageProvider
       end
 
       def repo_ready?(path)
-        (repo_prepared?(path) || repo_error?(path)) && !clonning?(path)
-      end
-
-      private
-
-      def repo_prepared?(path)
-        Dir.exist?(path) && File.exist?(path + PACKAGE_PART_READY)
-      end
-
-      def repo_error?(path)
-        File.exist?(path + PACKAGE_PART_READY) && File.exist?(path + ERROR)
-      end
-
-      def clonning?(path)
-        File.exist?(path + CLONE_LOCK)
+        (Dir.exist?(path) && File.exist?(path + PACKAGE_PART_READY)) ||
+          (File.exist?(path + PACKAGE_PART_READY) &&
+           File.exist?(path + ERROR)) && !File.exist?(path + CLONE_LOCK)
       end
     end
 
@@ -52,7 +40,7 @@ module PackageProvider
       end
 
       locked_file = lock_repo(cached_dir)
-      return cached_dir if CachedRepository.repo_ready?(cached_dir)
+      return cached_dir if File.exist?(cached_dir + PACKAGE_PART_READY)
       perform_and_handle_clone(req, cached_dir)
       repo_ready!(cached_dir)
 

--- a/spec/unit/lib/package_provider/cached_repository_spec.rb
+++ b/spec/unit/lib/package_provider/cached_repository_spec.rb
@@ -69,40 +69,4 @@ describe PackageProvider::CachedRepository do
       FileUtils.rm_rf(path + repo_clone)
     end
   end
-
-  describe '::repo_ready?' do
-    it 'returns true if repo has error' do
-      FileUtils.rm_rf(path)
-      FileUtils.touch(path + repo_error)
-      FileUtils.touch(path + repo_ready)
-
-      expect(PackageProvider::CachedRepository.repo_ready?(path))
-        .to be true
-    end
-
-    it 'returns true if repo is prepared' do
-      FileUtils.touch(path + repo_ready)
-
-      expect(PackageProvider::CachedRepository.repo_ready?(path))
-        .to be true
-    end
-
-    it 'returns false if clonning is in progress' do
-      FileUtils.touch(path + repo_error)
-      FileUtils.touch(path + repo_ready)
-
-      FileUtils.touch(path + repo_clone)
-
-      expect(PackageProvider::CachedRepository.repo_ready?(path))
-        .to be false
-    end
-
-    it 'returns false if repo folder or err file is not present' do
-      FileUtils.rm_rf(path)
-      FileUtils.touch(path + repo_ready)
-
-      expect(PackageProvider::CachedRepository.repo_ready?(path))
-        .to be false
-    end
-  end
 end


### PR DESCRIPTION
Reverts AVGTechnologies/package_provider#69

This commit will not work and needs to be reverted. The line return cached_dir if CachedRepository.repo_ready?(cached_dir) always evaluates to false because at evaluating time there is file .clone_lock presents. The line should be replaced with return cached_dir if CachedRepository.repo_prepared?(cached_dir) || CachedRepository.repo_error?(cached_dir).